### PR TITLE
fpioa: Fix access granularity issues

### DIFF
--- a/lib/drivers/include/fpioa.h
+++ b/lib/drivers/include/fpioa.h
@@ -834,7 +834,7 @@ typedef struct _fpioa_tie
  */
 typedef struct _fpioa
 {
-    fpioa_io_config_t io[FPIOA_NUM_IO];
+    uint32_t io[FPIOA_NUM_IO];
     /*!< FPIOA GPIO multiplexer io array */
     fpioa_tie_t tie;
     /*!< FPIOA GPIO multiplexer tie */


### PR DESCRIPTION
I've had some issues where fpioa configuration was seemingly ignored; this resulted in keypresses being ignored (in `kpu_conv` and other demos) where the buttons on the Maix Go were assigned to HSGPIO >= 4.

The problem is that accesses to packed structures can be optimized to byte acceses (`lb`, `sb` instructions, noticed with gcc 8.2.0) whereas the registers require 32-bit accesses. Avoid this by implementing an
explicit conversion between uint32_t and the configuration structure.